### PR TITLE
fix: URL path encoding

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -63,15 +63,16 @@ var toSlash = filepath.ToSlash
 
 // NewDocumentURI create a DocumentURI from the given string path
 func NewDocumentURI(path string) DocumentURI {
-	// tranform path into URI
+	// transform path into URI
 	path = toSlash(path)
 	if len(path) == 0 || path[0] != '/' {
 		path = "/" + path
 	}
-	uri, err := NewDocumentURIFromURL("file://" + path)
+	uri, err := NewDocumentURIFromURL("file://")
 	if err != nil {
 		panic(err)
 	}
+	uri.url.Path = path
 	return uri
 }
 

--- a/uri_test.go
+++ b/uri_test.go
@@ -20,6 +20,10 @@ func TestUriToPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "C:/Users/test/Sketch.ino", d.unbox())
 
+	d, err = NewDocumentURIFromURL("file:///C:/Users/test/Sketch%23suffix.ino")
+	require.NoError(t, err)
+	require.Equal(t, "C:/Users/test/Sketch#suffix.ino", d.unbox())
+
 	d, err = NewDocumentURIFromURL("file:///c%3A/Users/test/Sketch.ino")
 	require.NoError(t, err)
 	require.Equal(t, "c:/Users/test/Sketch.ino", d.unbox())
@@ -38,9 +42,12 @@ func TestUriToPath(t *testing.T) {
 }
 
 func TestPathToUri(t *testing.T) {
+	d := NewDocumentURI("/Users/test/Sketch#suffix.ino")
+	require.Equal(t, "file:///Users/test/Sketch%23suffix.ino", d.String())
+
 	toSlash = windowsToSlash // Emulate windows cases
 
-	d := NewDocumentURI("C:\\Users\\test\\Sketch.ino")
+	d = NewDocumentURI("C:\\Users\\test\\Sketch.ino")
 	require.Equal(t, "file:///C:/Users/test/Sketch.ino", d.String())
 	d = NewDocumentURI("/Users/test/Sketch.ino")
 	require.Equal(t, "file:///Users/test/Sketch.ino", d.String())


### PR DESCRIPTION
Fixes the path encoding when creating new URLs.

Instead of using `url.Parse` which cuts the fragment after `#` from the path, an empty URL is created with `file:` scheme, and the `Path` is assigned to the URL which will take care of the automatic segment encoding.


Ref: arduino/arduino-ide#1124
Signed-off-by: Akos Kitta <a.kitta@arduino.cc>