### PR TITLE
Fix for nvim 10+

### DIFF
--- a/jsonrpc/jsonrpc_protocol.go
+++ b/jsonrpc/jsonrpc_protocol.go
@@ -155,4 +155,4 @@ type ProgressParams struct {
 }
 
 // ProgressToken is a progress token
-type ProgressToken json.RawMessage
+type ProgressToken string


### PR DESCRIPTION
The arduino-language-server depends on this library. However, as of nvim 10.0, the LSP fails to attach to the buffer and it cannot be used.

- https://github.com/arduino/arduino-language-server/issues/187

A simple fix was recommended in the issue above to change the datatype for `jsonrcp.ProgressToken` from `json.RawMessage` to `string`. The original datatype `json.RawMessage` is itself an alias for a byte array so coercing to a string would just ensure the content is UTF-8 I think. I'm not too familiar with how LSPs work but I think it's reasonable to expect that all data is UTF-8 encoded.

Fixes #3.
